### PR TITLE
ADD ricopili.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN curl -Lo /tmp/rp_bin.tgz https://sites.google.com/a/broadinstitute.org/ricop
    tar zxvf /tmp/rp_bin.tgz -C /ricopili/
 
 
-RUN curl -o  /root/ricopili.conf https://github.com/bruggerk/ricopili_docker/ricopili.conf
+COPY ricopili.conf /root/
 
 
 ENV PATH /ricopili/rp_bin:/ricopili/rp_bin/pdfjam:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN curl -Lo /tmp/rp_bin.tgz https://sites.google.com/a/broadinstitute.org/ricop
 
 COPY ricopili.conf /root/
 
+RUN touch /root/preimp_dir_info
 
 ENV PATH /ricopili/rp_bin:/ricopili/rp_bin/pdfjam:$PATH
 ENV rp_perlpackages /ricopili/rp_dep/perl_modules/

--- a/ricopili.conf
+++ b/ricopili.conf
@@ -21,7 +21,7 @@ home /root
 sloc /scratch
 init RP
 email None
-loloc .
+loloc /root
 batch_jobcommand NA
 batch_name NA
 batch_jobfile NA


### PR DESCRIPTION
It looks like the curl request to copy down the ricopili.conf file was not working for me. I believe github will serve these files via `https://raw.github.com/...` rather than plain `https://www.github.com/`. That is another option here!